### PR TITLE
fix db init

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,3 @@
-from database import get_session, init_db
-from import_service import import_initial_inventory_from_json, import_production_orders_from_json, import_providers_from_json, import_purchase_orders_from_json, import_simulation_from_json
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -7,17 +5,12 @@ from pathlib import Path
 import endpoints
 import uvicorn
 from fastapi.middleware.cors import CORSMiddleware
+from db_init import init_db
 
 app = FastAPI(title="Supply Chain Simulator API")
 
 # Initialize database and import initial data
 init_db()
-import_simulation_from_json("data/plan.json")
-
-import_providers_from_json("data/providers.json")
-import_initial_inventory_from_json("data/inventory_init.json")
-# import_production_orders_from_json("data/production_orders.json")
-# import_purchase_orders_from_json("data/purchase_orders.json")
 
 
 app = FastAPI(title="Simulador Producción 3D")

--- a/app/database.py
+++ b/app/database.py
@@ -92,13 +92,6 @@ class DailyPlan(Base):
     status = Column(String, default="pending")  # pending, fulfilled, cancelled
 
 
-# --- INICIALIZACIÓN ---
-
-def init_db():
-    if not os.path.exists(DB_PATH):
-        print("Inicializando base de datos...")
-    Base.metadata.create_all(bind=engine)
-
 def get_session():
     return SessionLocal()
 

--- a/app/db_init.py
+++ b/app/db_init.py
@@ -1,0 +1,16 @@
+from database import Base, engine, DB_PATH
+import os
+from import_service import import_initial_inventory_from_json, import_production_orders_from_json, import_providers_from_json, import_purchase_orders_from_json, import_simulation_from_json
+
+def init_db():
+    if not os.path.exists(DB_PATH):
+        print("Inicializando base de datos...")
+        Base.metadata.create_all(bind=engine)
+        import_simulation_from_json("data/plan.json")
+        import_providers_from_json("data/providers.json")
+        import_initial_inventory_from_json("data/inventory_init.json")
+        # import_production_orders_from_json("data/production_orders.json")
+        # import_purchase_orders_from_json("data/purchase_orders.json")
+
+    else:
+        Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
Añadir logica para cuando la db ya existe.
- En ese caso no es necesario importar estado inicial db (proveedores, pedidos, ...)